### PR TITLE
Fix debugger

### DIFF
--- a/src/Debugger.hpp
+++ b/src/Debugger.hpp
@@ -48,6 +48,7 @@ private:
   int _frame_size = 10;
   std::chrono::time_point<std::chrono::high_resolution_clock> _past;
   static int _first_time;
+  bool _in_vb = false;
 
   std::vector<_debug_info> _instr_pool;
   std::vector<uint16_t> _breakpoint_pool;

--- a/src/PPU.hpp
+++ b/src/PPU.hpp
@@ -51,6 +51,7 @@ public:
 	void					set_bit(uint8_t & src, uint8_t bit_number);
 	void					unset_bit(uint8_t & src, uint8_t bit_number);
 	void					update_graphics(Word cycles);
+	Byte				get_ly() const {return _ly;}
 
 	static constexpr Word	LCDC = 0xFF40;
 	static constexpr Word	STAT = 0xFF41;

--- a/src/ui/debuggerwindow.cpp
+++ b/src/ui/debuggerwindow.cpp
@@ -312,7 +312,7 @@ void DebuggerWindow::on_runOneFrameButton_clicked()
 
 void DebuggerWindow::on_runDurationButton_clicked()
 {
-	g_gameboy->notify_debugger(Debugger::RUN_CPU_SEC, ui->runDurationSpinBox->value());
+	g_gameboy->notify_debugger(Debugger::RUN_DURATION , ui->runDurationSpinBox->value());
 	while (!g_gameboy->get_debugger().get_lock()){}
 	refresh_info();
 }


### PR DESCRIPTION
run one frame infinite loop is due to bad implementsation of _ly which is fixed in ppu_sprite_fix
call the correct function in debuggerwindow && remove breakpoint is safe now