### PR TITLE
Change Default bios type to cgb

### DIFF
--- a/src/Bios.cpp
+++ b/src/Bios.cpp
@@ -1,11 +1,14 @@
 #include "src/Bios.hpp"
 
 #include <cassert>
+#include <iostream>
 
 const std::vector<Byte>& Bios::get_bios() const {
   switch (_type) {
     case GbType::CGB:
       return s_cgb_bios;
+	case GbType::CGB_DMG:
+	  return s_cgb_bios;
     default:
       return s_dmg_bios;
   }

--- a/src/Bios.hpp
+++ b/src/Bios.hpp
@@ -22,7 +22,7 @@ private:
 
   const std::vector<Byte>& get_bios() const;
 
-  GbType _type = GbType::Unknown;
+  GbType _type = GbType::DMG;
 
 public:
   Byte read(Word addr) const { return get_bios()[addr]; }

--- a/src/Gameboy.cpp
+++ b/src/Gameboy.cpp
@@ -189,8 +189,10 @@ void Gameboy::do_checksum() {
 
 void Gameboy::read_type() {
   Byte value = _components.mem_bus->read<Byte>(0x143);
-  if (value == 0x80 or value == 0xC0)
+  if (value == 0xC0)
     _type = GbType::CGB;
+  else if (value == 0x80)
+	  _type = GbType::CGB_DMG;
   else
     _type = GbType::DMG;
 }

--- a/src/GbType.hpp
+++ b/src/GbType.hpp
@@ -2,8 +2,8 @@
 #define GBTYPE_HPP
 
 enum class GbType {
-  Unknown = 0,
-  DMG = 0x80,
+  DMG = 0,
+  CGB_DMG = 0x80,
   CGB = 0xC0,
 };
 

--- a/src/PPU.cpp
+++ b/src/PPU.cpp
@@ -614,10 +614,10 @@ void PPU::setup_gb_mode() {
 
   if (_gb_mode == 0) {
     mode_flag = _components.mem_bus->read<Byte>(0x0143);
-    if (mode_flag == 0xC0 || mode_flag == 0x80) {
+    if (mode_flag == 0xC0) {
       _gb_mode = MODE_GB_CGB;
     } else if (mode_flag == 0x80) {
-      _gb_mode = MODE_GB_DMGC;
+      _gb_mode = MODE_GB_CGB; // Need to set custom palettes
     } else {
       _gb_mode = MODE_GB_DMG;
     }


### PR DESCRIPTION
0x80 means that the cartridge is dmg but compatible with cgb, palettes will be forced, if not, player may need to force dmg bios